### PR TITLE
Add order persistence and stock update

### DIFF
--- a/AppCore/Sources/AppCore/ShopView.swift
+++ b/AppCore/Sources/AppCore/ShopView.swift
@@ -6,6 +6,7 @@ import DataModels
 struct ShopView: View {
     @StateObject private var repo = ProductRepository()
     @State private var showError = false
+    @State private var showSuccess = false
 
     var body: some View {
         NavigationView {
@@ -27,10 +28,22 @@ struct ShopView: View {
         } message: {
             Text("Unable to complete purchase.")
         }
+        .alert("Success", isPresented: $showSuccess) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Purchase complete!")
+        }
     }
 
     private func purchase(_ product: Product) {
-        ApplePayHandler().startPayment(for: product)
+        ApplePayHandler(orderRepository: OrderRepository()).startPayment(for: product) { result in
+            switch result {
+            case .success:
+                showSuccess = true
+            case .failure:
+                showError = true
+            }
+        }
     }
 }
 

--- a/CommerceKit/Sources/CommerceKit/ApplePayHandler.swift
+++ b/CommerceKit/Sources/CommerceKit/ApplePayHandler.swift
@@ -9,11 +9,23 @@ import DataModels
 /// decrementing or receipt validation are left for future iterations.
 public final class ApplePayHandler: NSObject {
 
+    private let orderRepository: OrderRepository
+    private var currentProduct: Product?
+    private var resultHandler: ((Result<Void, Error>) -> Void)?
+
+    public init(orderRepository: OrderRepository = OrderRepository()) {
+        self.orderRepository = orderRepository
+    }
+
     // MARK: - Public entry point
 
-    public func startPayment(for product: Product) {
+    public func startPayment(for product: Product,
+                             completion: @escaping (Result<Void, Error>) -> Void) {
+        self.currentProduct = product
+        self.resultHandler = completion
         guard PKPaymentAuthorizationController.canMakePayments() else {
             print("[ApplePayHandler] Device cannot make payments")
+            completion(.failure(NSError(domain: "ApplePay", code: 0, userInfo: [NSLocalizedDescriptionKey: "Device cannot make payments"])))
             return
         }
 
@@ -37,8 +49,41 @@ public final class ApplePayHandler: NSObject {
     }
 
     // MARK: - Private helpers
-
     private static let merchantIdentifier = "merchant.com.cosmochat"
+
+    private func decrementStock(for product: Product) async throws {
+        let zone = CKRecordZone.ID(zoneName: "Shop", ownerName: CKCurrentUserDefaultName)
+        let id = CKRecord.ID(recordName: product.sku, zoneID: zone)
+        var attempts = 0
+
+        while true {
+            attempts += 1
+            var record = try await CKDatabaseProxy.public.fetchRecord(id: id)
+            let current = record["stock"] as? Int ?? 0
+            record["stock"] = max(current - 1, 0) as CKRecordValue
+
+            do {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    let op = CKModifyRecordsOperation(recordsToSave: [record])
+                    op.savePolicy = .ifServerRecordUnchanged
+                    op.modifyRecordsResultBlock = { result in
+                        switch result {
+                        case .success:
+                            continuation.resume(returning: ())
+                        case .failure(let error):
+                            continuation.resume(throwing: error)
+                        }
+                    }
+                    CKContainer.cosmic.publicCloudDatabase.add(op)
+                }
+                break
+            } catch let ckError as CKError where ckError.code == .serverRecordChanged && attempts < 3 {
+                continue
+            } catch {
+                throw error
+            }
+        }
+    }
 }
 
 // MARK: - PKPaymentAuthorizationControllerDelegate
@@ -46,16 +91,39 @@ public final class ApplePayHandler: NSObject {
 extension ApplePayHandler: PKPaymentAuthorizationControllerDelegate {
     public func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
         controller.dismiss(completion: nil)
+        currentProduct = nil
+        resultHandler = nil
     }
 
     public func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController,
                                                didAuthorizePayment payment: PKPayment,
                                                handler completion: @escaping (PKPaymentAuthorizationResult) -> Void) {
-        // For MVP we just mark success immediately and create an Order record.
-        // For this MVP stub we immediately return success; persistence will be
-        // implemented in a future story.
-        completion(.init(status: .success, errors: nil))
+        guard let product = currentProduct else {
+            completion(.init(status: .failure, errors: nil))
+            resultHandler?(.failure(NSError(domain: "ApplePay", code: 1, userInfo: nil)))
+            return
+        }
+
+        Task {
+            do {
+                try await decrementStock(for: product)
+
+                var record = CKRecord(recordType: Order.recordType)
+                record["productSKU"] = product.sku as CKRecordValue
+                record["quantity"] = 1 as CKRecordValue
+                record["totalAmount"] = product.price as CKRecordValue
+                record["currency"] = product.currency as CKRecordValue
+
+                let order = try Order(record: record)
+                try await orderRepository.save(order)
+
+                completion(.init(status: .success, errors: nil))
+                resultHandler?(.success(()))
+            } catch {
+                completion(.init(status: .failure, errors: [error]))
+                resultHandler?(.failure(error))
+            }
+        }
     }
 
-    // No-op stub – real order persistence TBD.
 }


### PR DESCRIPTION
## Summary
- implement order persistence using `CKModifyRecordsOperation`
- inject `OrderRepository` into `ApplePayHandler`
- decrement stock on successful Apple Pay authorization with conflict retries
- surface success/failure to ShopView UI

## Testing
- `swift test --enable-test-discovery` *(fails: no such module 'CloudKit')*
- `swift test --enable-test-discovery` in DataModels *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6840f4a53d3c832abe163db16311108b