### PR TITLE
Add SavedMatch repository

### DIFF
--- a/AppCore/Sources/AppCore/MatchView.swift
+++ b/AppCore/Sources/AppCore/MatchView.swift
@@ -7,6 +7,7 @@ struct MatchView: View {
     @State private var partnerName: String = ""
     @State private var partnerDOB: Date = .init()
     @State private var score: KundaliMatch?
+    @StateObject private var repo = SavedMatchRepository()
 
     var body: some View {
         NavigationView {
@@ -23,6 +24,9 @@ struct MatchView: View {
                     Section(header: Text("Score")) {
                         Text("Total Points: \(score.scoreTotal)/36")
                             .font(.title3.weight(.semibold))
+                        Button("Save Match") {
+                            Task { try? await repo.save(score) }
+                        }
                     }
                 }
             }

--- a/DataModels/Sources/DataModels/SavedMatchRepository.swift
+++ b/DataModels/Sources/DataModels/SavedMatchRepository.swift
@@ -1,0 +1,45 @@
+import Foundation
+import CloudKit
+import CloudKitKit
+
+/// Repository for saving and retrieving `KundaliMatch` records in the private database.
+public final class SavedMatchRepository: ObservableObject {
+    @Published public private(set) var matches: [KundaliMatch] = []
+
+    private let database: CKDatabaseProxy
+
+    public init(database: CKDatabaseProxy = .private) {
+        self.database = database
+    }
+
+    /// Persists a match to the user's private CloudKit zone.
+    public func save(_ match: KundaliMatch) async throws {
+        _ = try await database.save(match, zone: CKRecordZone.default().zoneID)
+    }
+
+    /// Fetches a specific saved match by record ID.
+    public func load(id: CKRecord.ID) async throws -> KundaliMatch {
+        try await database.fetch(type: KundaliMatch.self, id: id)
+    }
+
+    /// Refresh the list of saved matches ordered by creation time.
+    @MainActor
+    public func refresh() async {
+        do {
+            let items: [KundaliMatch] = try await database.query(
+                type: KundaliMatch.self,
+                predicate: NSPredicate(value: true),
+                sortDescriptors: [NSSortDescriptor(key: "creationDate", ascending: false)],
+                zoneID: CKRecordZone.default().zoneID
+            )
+            matches = items
+        } catch {
+            print("[SavedMatchRepository] fetch error: \(error)")
+        }
+    }
+
+    /// Deletes a saved match by its record ID.
+    public func delete(id: CKRecord.ID) async throws {
+        try await database.delete(type: KundaliMatch.self, id: id)
+    }
+}


### PR DESCRIPTION
## Summary
- create `SavedMatchRepository` to manage KundaliMatch records in CloudKit
- expose save/list/load/delete APIs
- hook repository into Match wizard with a *Save Match* button

## Testing
- `swift test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6840f4a29dec832ab2b29cbc6178b2da