### PR TITLE
Add placeholder chat and profile tabs

### DIFF
--- a/AppCore/Sources/AppCore/AppRouter.swift
+++ b/AppCore/Sources/AppCore/AppRouter.swift
@@ -20,11 +20,11 @@ public struct AppRouter {
         case .match:
             MatchView()
         case .chat:
-            Text("Chat View Placeholder") // Deferred feature
+            ChatView()
         case .shop:
             ShopView()
         case .profile:
-            Text("Profile View Placeholder")
+            ProfileView()
         }
     }
 }

--- a/AppCore/Sources/AppCore/ChatView.swift
+++ b/AppCore/Sources/AppCore/ChatView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// Simple view for chats; currently lists no conversations.
+struct ChatView: View {
+    var body: some View {
+        NavigationView {
+            Text("No messages yet")
+                .foregroundStyle(.secondary)
+                .navigationTitle("Chat")
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    ChatView()
+}
+#endif

--- a/AppCore/Sources/AppCore/ProfileView.swift
+++ b/AppCore/Sources/AppCore/ProfileView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import AuthKit
+
+/// Basic account screen with a sign-out button.
+struct ProfileView: View {
+    @EnvironmentObject private var auth: AuthManager
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Button("Sign Out", role: .destructive) {
+                    Task { await auth.signOut() }
+                }
+            }
+            .navigationTitle("Profile")
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    ProfileView()
+        .environmentObject(AuthManager())
+}
+#endif

--- a/AppCore/Sources/AppCore/TabBarView.swift
+++ b/AppCore/Sources/AppCore/TabBarView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Main tab bar hosting the three core verticals for the MVP release.
+/// Main tab bar hosting the five core verticals for the MVP release.
 struct TabBarView: View {
     @State private var selection: Int = 0
 
@@ -14,9 +14,17 @@ struct TabBarView: View {
                 .tabItem { Label("Match", systemImage: "heart.circle") }
                 .tag(1)
 
+            ChatView()
+                .tabItem { Label("Chat", systemImage: "message") }
+                .tag(2)
+
             ShopView()
                 .tabItem { Label("Shop", systemImage: "bag") }
-                .tag(2)
+                .tag(3)
+
+            ProfileView()
+                .tabItem { Label("Profile", systemImage: "person.crop.circle") }
+                .tag(4)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add basic `ChatView` and `ProfileView`
- extend `TabBarView` with Chat and Profile tabs
- update `AppRouter` to return the new views
- refine placeholder content and add sign-out button

## Testing
- `swift test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6840fa5ab598832aa3b423ed313ce9f2