### PR TITLE
Add Settings persistence via CloudKit and UserDefaults

### DIFF
--- a/SettingsKit/Package.swift
+++ b/SettingsKit/Package.swift
@@ -9,9 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../CloudKitKit"),
+        .package(path: "../DataModels"),
     ],
     targets: [
-        .target(name: "SettingsKit", dependencies: ["CloudKitKit"]),
+        .target(name: "SettingsKit", dependencies: ["CloudKitKit", "DataModels"]),
         .testTarget(name: "SettingsKitTests", dependencies: ["SettingsKit"]),
     ]
 )

--- a/SettingsKit/Sources/SettingsKit/LanguageManager.swift
+++ b/SettingsKit/Sources/SettingsKit/LanguageManager.swift
@@ -1,6 +1,50 @@
 import Foundation
+import CloudKit
+import CloudKitKit
 
 /// Manages app language selection and localization.
 public final class LanguageManager {
-    public init() {}
+    private let defaults: UserDefaults
+    private let database: CKDatabaseProxy
+
+    private static let kLangKey = "settings.language"
+
+    public init(database: CKDatabaseProxy = .private,
+                defaults: UserDefaults = .standard) {
+        self.database = database
+        self.defaults = defaults
+    }
+
+    /// Loads the preferred language from defaults and CloudKit.
+    public func loadLanguage(default defaultLang: String = Locale.current.identifier) async -> String {
+        var lang = defaults.string(forKey: Self.kLangKey) ?? defaultLang
+
+        do {
+            let id = CKRecord.ID(recordName: "language", zoneID: CKRecordZone.default().zoneID)
+            let record = try await database.fetchRecord(id: id)
+            if let cloud = record["identifier"] as? String {
+                lang = cloud
+                defaults.set(cloud, forKey: Self.kLangKey)
+            }
+        } catch { }
+
+        return lang
+    }
+
+    /// Persists the language to defaults and CloudKit.
+    public func saveLanguage(_ identifier: String) async {
+        defaults.set(identifier, forKey: Self.kLangKey)
+
+        do {
+            let id = CKRecord.ID(recordName: "language", zoneID: CKRecordZone.default().zoneID)
+            let record: CKRecord
+            do {
+                record = try await database.fetchRecord(id: id)
+            } catch {
+                record = CKRecord(recordType: "LanguagePrefs", recordID: id)
+            }
+            record["identifier"] = identifier as CKRecordValue
+            _ = try await database.saveRecord(record)
+        } catch { }
+    }
 }

--- a/SettingsKit/Sources/SettingsKit/NotificationPrefs.swift
+++ b/SettingsKit/Sources/SettingsKit/NotificationPrefs.swift
@@ -1,10 +1,38 @@
 import Foundation
+import CloudKit
+import DataModels
 
-/// User notification preference flags persisted in settings.
-public struct NotificationPrefs: Codable {
+/// CloudKit record representing user notification preferences.
+public struct NotificationPrefs: Codable, CKRecordConvertible {
+    /// CloudKit record type name.
+    public static let recordType = "NotificationPrefs"
+
     public var dailyEnabled: Bool
 
     public init(dailyEnabled: Bool = true) {
         self.dailyEnabled = dailyEnabled
+    }
+
+    // MARK: - CKRecordConvertible
+
+    public init(record: CKRecord) throws {
+        guard let enabled = record["dailyEnabled"] as? Int else {
+            throw NSError(domain: "SettingsKit",
+                          code: 0,
+                          userInfo: [NSLocalizedDescriptionKey: "Missing dailyEnabled field"])
+        }
+        self.dailyEnabled = enabled == 1
+    }
+
+    public func toRecord(in zone: CKRecordZone.ID?) -> CKRecord {
+        let record: CKRecord
+        if let zoneID = zone {
+            let id = CKRecord.ID(recordName: "prefs", zoneID: zoneID)
+            record = CKRecord(recordType: Self.recordType, recordID: id)
+        } else {
+            record = CKRecord(recordType: Self.recordType)
+        }
+        record["dailyEnabled"] = (dailyEnabled ? 1 : 0) as CKRecordValue
+        return record
     }
 }

--- a/SettingsKit/Sources/SettingsKit/SettingsViewModel.swift
+++ b/SettingsKit/Sources/SettingsKit/SettingsViewModel.swift
@@ -1,13 +1,89 @@
 import Foundation
 import Combine
 import CloudKitKit
+import CloudKit
 
 /// ViewModel for managing user settings persisted in CloudKit and UserDefaults.
 @available(iOS 13.0, *)
 public final class SettingsViewModel: ObservableObject {
     @Published public var selectedLanguage: String
+    @Published public var notificationPrefs: NotificationPrefs
 
-    public init(defaultLanguage: String = Locale.current.identifier) {
+    private let database: CKDatabaseProxy
+    private let defaults: UserDefaults
+
+    private static let kLangKey  = "settings.language"
+    private static let kNotifKey = "settings.notification"
+
+    public init(defaultLanguage: String = Locale.current.identifier,
+                database: CKDatabaseProxy = .private,
+                defaults: UserDefaults = .standard) {
+        self.database = database
+        self.defaults = defaults
         self.selectedLanguage = defaultLanguage
+        self.notificationPrefs = NotificationPrefs()
+        loadFromDefaults()
+        Task { await loadFromCloud() }
+    }
+
+    private func loadFromDefaults() {
+        if let lang = defaults.string(forKey: Self.kLangKey) {
+            selectedLanguage = lang
+        }
+        if let data = defaults.data(forKey: Self.kNotifKey),
+           let prefs = try? JSONDecoder().decode(NotificationPrefs.self, from: data) {
+            notificationPrefs = prefs
+        }
+    }
+
+    private func saveToDefaults() {
+        defaults.set(selectedLanguage, forKey: Self.kLangKey)
+        if let data = try? JSONEncoder().encode(notificationPrefs) {
+            defaults.set(data, forKey: Self.kNotifKey)
+        }
+    }
+
+    @MainActor
+    public func loadFromCloud() async {
+        do {
+            let langID = CKRecord.ID(recordName: "language", zoneID: CKRecordZone.default().zoneID)
+            let record = try await database.fetchRecord(id: langID)
+            if let lang = record["identifier"] as? String {
+                selectedLanguage = lang
+            }
+        } catch { }
+
+        do {
+            let notifID = CKRecord.ID(recordName: "prefs", zoneID: CKRecordZone.default().zoneID)
+            let prefs: NotificationPrefs = try await database.fetch(type: NotificationPrefs.self, id: notifID)
+            notificationPrefs = prefs
+        } catch { }
+
+        saveToDefaults()
+    }
+
+    @MainActor
+    public func saveToCloud() async {
+        saveToDefaults()
+
+        do {
+            let langID = CKRecord.ID(recordName: "language", zoneID: CKRecordZone.default().zoneID)
+            let record: CKRecord
+            do {
+                record = try await database.fetchRecord(id: langID)
+            } catch {
+                record = CKRecord(recordType: "LanguagePrefs", recordID: langID)
+            }
+            record["identifier"] = selectedLanguage as CKRecordValue
+            _ = try await database.saveRecord(record)
+        } catch {
+            print("[SettingsViewModel] failed to save language: \(error)")
+        }
+
+        do {
+            _ = try await database.save(notificationPrefs, zone: CKRecordZone.default().zoneID)
+        } catch {
+            print("[SettingsViewModel] failed to save notification prefs: \(error)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support storing preferences in CloudKit with a NotificationPrefs record
- load/save notification and language settings in SettingsViewModel
- manage language persistence in LanguageManager
- link SettingsKit with DataModels for CKRecordConvertible

## Testing
- `swift build` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_68413cf7e034832ab189d923ce677143